### PR TITLE
Add Favicon Support and Remove Unnecessary Support Codes Which Can Be Edited Through Customizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This child theme can be used to override styles and features of the [Independent
 
 ## Installation
 
-This [Child Theme](http://codex.wordpress.org/Child_Themes) requires the parent Independent Publisher theme, so be sure that you have that installed first. Then, simply download this child theme and place it your `wp-content/themes/` folder and then activate it from **Appearance → Themes**. 
+This [Child Theme](http://codex.wordpress.org/Child_Themes) requires the parent Independent Publisher theme, so be sure that you have that installed first. Then, simply download this child theme and place it your `wp-content/themes/` folder and then activate it from **Appearance → Themes**.
 
 **IMPORTANT NOTE:** If you downloaded the Independent Publisher theme from GitHub, the theme folder name might be `independent-publisher-master`. If that is the case, _you must_ rename the theme directory to `independent-publisher`, as that is what the Child Theme looks for.
 
@@ -17,4 +17,4 @@ See the comments in `style.css` and `functions.php` for examples.
 
 A [Page Template](http://codex.wordpress.org/Page_Templates#Custom_Page_Template) can be selected from the Page Attributes meta box when editing or creating a new WordPress Page. The following page templates are included in this Child Theme:
 
- * **Archive Page:** Displays Search box, Recent Posts, Most Used Categories, Monthly Archives, and Tag Cloud. 
+ * **Archive Page:** Displays Search box, Recent Posts, Most Used Categories, Monthly Archives, and Tag Cloud.

--- a/functions.php
+++ b/functions.php
@@ -6,11 +6,6 @@
  *
  */
 
-// Uncomment this line to hide the post word count:
-// function independent_publisher_get_post_word_count() { return false; }
-
-// Uncomment this line to enable multi-author mode:
-// function independent_publisher_is_multi_author_mode() { return true; }
 
 // Add a favicon to your site. You need to add favicon image to the images folder of Independent Publisher Child Theme for this to work.
 function blog_favicon() {

--- a/functions.php
+++ b/functions.php
@@ -11,3 +11,9 @@
 
 // Uncomment this line to enable multi-author mode:
 // function independent_publisher_is_multi_author_mode() { return true; }
+
+// Add a favicon to your site. You need to add favicon image to the images folder of Independent Publisher Child Theme for this to work.
+function blog_favicon() {
+  echo '<link rel="Shortcut Icon" type="image/x-icon" href="'.get_bloginfo('stylesheet_directory').'/images/favicon.ico" />' . "\n";
+}
+add_action('wp_head', 'blog_favicon');


### PR DESCRIPTION
Independent Publisher doesn't have favicon support, so I thought of adding it on the Child theme. 

We can Enable 'Multi-Author Mode', and hide 'Post Word Count' through the Customizer. So, I've removed those support codes. 

I've also removed trailing spaces from the README.md file. 
